### PR TITLE
Clarify ripple-lib vs xrpl.js and what this repo uses.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Create-react-app + XRPL sandbox
 
+**Note: `ripple-lib` is the older version of the client, it is now `xrpl.js`. This repo needs to be updated to consume the new client.**
+
 Putting the typescript XRPL client, [`ripple-lib`](https://github.com/ripple/ripple-lib), in a CRA app so it can be sandboxed and experimented with easily. Developers can:
 
 1. `git clone https://github.com/ahoym/cra-xrpl-sandbox.git`
@@ -14,8 +16,8 @@ See the `xrpl` reference documentation for more details: https://xrpl.org/ripple
 ## Recommended Tooling/Setup ##
 
 - [Get `volta`](https://volta.sh/) for node/yarn version management
-- [Get `homebrew`](https://brew.sh/) for macOS package management
-- [Get and use `yarn`](https://classic.yarnpkg.com/en/docs/install/#homebrew) instead of `npm`
+- (Optional, may not be necessary with `volta`) [Get `homebrew`](https://brew.sh/) for macOS package management
+- (Optional, may not be necessary with `volta`) [Get and use `yarn`](https://classic.yarnpkg.com/en/docs/install/#homebrew) instead of `npm`
   - `brew install yarn`
 
 # Getting Started with Create React App

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ And play around with the library in the browser web console + enjoy auto updates
 
 See the `xrpl` reference documentation for more details: https://xrpl.org/rippleapi-reference.html
 
-## Recommended Tooling/Setup ##
+## Recommended Tooling/Setup
 
 - [Get `volta`](https://volta.sh/) for node/yarn version management
 - (Optional, may not be necessary with `volta`) [Get `homebrew`](https://brew.sh/) for macOS package management


### PR DESCRIPTION
## Summary

This CRA repo was set up before xrpl.js became solidly public, so it uses ripple-lib which is the older client.

Work to update this to use xrpl.js will be done in the near future, but until then, this aspect needs to be clarified.

## Changes
- Add note that this repo uses the older client `ripple-lib` instead of `xrpl.js`
- Clarify recommended tooling, `volta` should be able to handle `yarn` as well.

