### PR TITLE
Abstract nft functionality into its own module

### DIFF
--- a/src/XrplSandbox/NFTokens/nftClient.ts
+++ b/src/XrplSandbox/NFTokens/nftClient.ts
@@ -3,6 +3,29 @@ import { Amount } from 'xrpl/dist/npm/models/common';
 import { StateRefProvider } from '../types';
 
 /**
+ * For cases where a buyer can accept a sell offer from a NFT owner.
+ * {@link https://xrpl.org/nftokenacceptoffer.html}
+ */
+export const acceptNftSellOffer = async (
+  stateRefProvider: StateRefProvider,
+  offerIndex: string,
+  brokerFee?: Amount
+): Promise<TxResponse> => {
+  const { client, wallet } = await stateRefProvider();
+  const acceptNftSellOfferPayload: NFTokenAcceptOffer = {
+    TransactionType: 'NFTokenAcceptOffer',
+    Account: wallet.address,
+    SellOffer: offerIndex,
+  };
+
+  if (brokerFee) {
+    acceptNftSellOfferPayload.BrokerFee = brokerFee;
+  }
+
+  return client.submitAndWait(acceptNftSellOfferPayload, { wallet });
+};
+
+/**
  * {@link https://xrpl.org/nftokenacceptoffer.html}
  */
 export const acceptNftBuyOffer = async (

--- a/src/XrplSandbox/NFTokens/nftClient.ts
+++ b/src/XrplSandbox/NFTokens/nftClient.ts
@@ -1,5 +1,6 @@
 import {
   NFTokenAcceptOffer,
+  NFTokenBurn,
   NFTokenCancelOffer,
   NFTokenCreateOffer,
   NFTokenCreateOfferFlags,
@@ -9,6 +10,23 @@ import {
 import { Amount } from 'xrpl/dist/npm/models/common';
 import { MS_IN_S, RIPPLE_EPOCH_IN_MS } from '../constants';
 import { StateRefProvider } from '../types';
+
+/**
+ * {@link https://xrpl.org/nftokenburn.html}
+ */
+export const burnNft = async (
+  stateRefProvider: StateRefProvider,
+  tokenId: string
+): Promise<TxResponse> => {
+  const { client, wallet } = await stateRefProvider();
+  const burnNftTxPayload: NFTokenBurn = {
+    TransactionType: 'NFTokenBurn',
+    Account: wallet.address,
+    TokenID: tokenId,
+  };
+
+  return client.submitAndWait(burnNftTxPayload, { wallet });
+};
 
 /**
  * Note that this transaction type is used for both BUY and SELLs.

--- a/src/XrplSandbox/NFTokens/nftClient.ts
+++ b/src/XrplSandbox/NFTokens/nftClient.ts
@@ -49,6 +49,22 @@ export const createNftBuyOffer = async (
   return client.submitAndWait(nfTokenCreateBuyOfferPayload, { wallet });
 };
 
+export const listNftSellOffers = async (
+  stateRefProvider: StateRefProvider,
+  tokenId: string
+) => {
+  const { client } = await stateRefProvider();
+
+  try {
+    return await client.request({
+      command: 'nft_sell_offers',
+      tokenid: tokenId,
+    });
+  } catch (error: unknown) {
+    return [];
+  }
+};
+
 export const listNftBuyOffers = async (
   stateRefProvider: StateRefProvider,
   tokenId: string

--- a/src/XrplSandbox/NFTokens/nftClient.ts
+++ b/src/XrplSandbox/NFTokens/nftClient.ts
@@ -1,0 +1,26 @@
+import { NFTokenAcceptOffer, TxResponse } from 'xrpl';
+import { Amount } from 'xrpl/dist/npm/models/common';
+import { StateRefProvider } from '../types';
+
+/**
+ * {@link https://xrpl.org/nftokenacceptoffer.html}
+ */
+export const acceptNftBuyOffer = async (
+  stateRefProvider: StateRefProvider,
+  offerIndex: string,
+  brokerFee?: Amount
+): Promise<TxResponse> => {
+  const { client, wallet } = await stateRefProvider();
+
+  const acceptNftBuyOfferPayload: NFTokenAcceptOffer = {
+    TransactionType: 'NFTokenAcceptOffer',
+    Account: wallet.address,
+    BuyOffer: offerIndex,
+  };
+
+  if (brokerFee) {
+    acceptNftBuyOfferPayload.BrokerFee = brokerFee;
+  }
+
+  return client.submitAndWait(acceptNftBuyOfferPayload, { wallet });
+};

--- a/src/XrplSandbox/NFTokens/nftClient.ts
+++ b/src/XrplSandbox/NFTokens/nftClient.ts
@@ -2,6 +2,22 @@ import { NFTokenAcceptOffer, NFTokenCancelOffer, TxResponse } from 'xrpl';
 import { Amount } from 'xrpl/dist/npm/models/common';
 import { StateRefProvider } from '../types';
 
+export const listNftBuyOffers = async (
+  stateRefProvider: StateRefProvider,
+  tokenId: string
+) => {
+  const { client } = await stateRefProvider();
+
+  try {
+    return await client.request({
+      command: 'nft_buy_offers',
+      tokenid: tokenId,
+    });
+  } catch (error: unknown) {
+    return [];
+  }
+};
+
 /**
  * {@link https://xrpl.org/nftokencanceloffer.html}
  * @param tokenOfferIndices array of NFT offer `index`es

--- a/src/XrplSandbox/NFTokens/nftClient.ts
+++ b/src/XrplSandbox/NFTokens/nftClient.ts
@@ -1,6 +1,24 @@
-import { NFTokenAcceptOffer, TxResponse } from 'xrpl';
+import { NFTokenAcceptOffer, NFTokenCancelOffer, TxResponse } from 'xrpl';
 import { Amount } from 'xrpl/dist/npm/models/common';
 import { StateRefProvider } from '../types';
+
+/**
+ * {@link https://xrpl.org/nftokencanceloffer.html}
+ * @param tokenOfferIndices array of NFT offer `index`es
+ */
+export const cancelNftOffers = async (
+  stateRefProvider: StateRefProvider,
+  tokenOfferIndices: string[]
+) => {
+  const { client, wallet } = await stateRefProvider();
+  const cancelNftOffersPayload: NFTokenCancelOffer = {
+    TransactionType: 'NFTokenCancelOffer',
+    Account: wallet.address,
+    TokenOffers: tokenOfferIndices,
+  };
+
+  return client.submitAndWait(cancelNftOffersPayload, { wallet });
+};
 
 /**
  * For cases where a buyer can accept a sell offer from a NFT owner.

--- a/src/XrplSandbox/NFTokens/nftClient.ts
+++ b/src/XrplSandbox/NFTokens/nftClient.ts
@@ -12,6 +12,18 @@ import { MS_IN_S, RIPPLE_EPOCH_IN_MS } from '../constants';
 import { StateRefProvider } from '../types';
 
 /**
+ * View all NFTs associated to stateRefProvider().wallet
+ */
+export const viewOwnNfts = async (stateRefProvider: StateRefProvider) => {
+  const { client, wallet } = await stateRefProvider();
+
+  return client.request({
+    command: 'account_nfts',
+    account: wallet.address,
+  });
+};
+
+/**
  * {@link https://xrpl.org/nftokenburn.html}
  */
 export const burnNft = async (

--- a/src/XrplSandbox/XrplClient.ts
+++ b/src/XrplSandbox/XrplClient.ts
@@ -14,6 +14,7 @@ import {
 } from 'xrpl';
 import { Amount } from 'xrpl/dist/npm/models/common';
 import { MS_IN_S, RIPPLE_EPOCH_IN_MS } from './constants';
+import { acceptNftBuyOffer } from './NFTokens/nftClient';
 
 export class XrplClient {
   #client: Client;
@@ -281,24 +282,8 @@ export class XrplClient {
     return this.#client.submitAndWait(acceptNftSellOfferPayload, { wallet });
   };
 
-  /**
-   * {@link https://xrpl.org/nftokenacceptoffer.html}
-   */
-  public acceptNftBuyOffer = async (
-    offerIndex: string,
-    brokerFee?: Amount
-  ): Promise<TxResponse> => {
-    const wallet = await this.connectAndGetWallet();
-    const acceptNftBuyOfferPayload: NFTokenAcceptOffer = {
-      TransactionType: 'NFTokenAcceptOffer',
-      Account: wallet.address,
-      BuyOffer: offerIndex,
-    };
-
-    if (brokerFee) {
-      acceptNftBuyOfferPayload.BrokerFee = brokerFee;
-    }
-
-    return this.#client.submitAndWait(acceptNftBuyOfferPayload, { wallet });
-  };
+  public acceptNftBuyOffer = acceptNftBuyOffer.bind(
+    null,
+    this.stateRefProvider
+  );
 }

--- a/src/XrplSandbox/XrplClient.ts
+++ b/src/XrplSandbox/XrplClient.ts
@@ -1,7 +1,6 @@
 import {
   Client,
   ClientOptions,
-  NFTokenBurn,
   NFTokenMint,
   NFTokenMintFlags,
   TxResponse,
@@ -11,6 +10,7 @@ import {
 import {
   acceptNftBuyOffer,
   acceptNftSellOffer,
+  burnNft,
   cancelNftOffers,
   createNftBuyOffer,
   createNftSellOffer,
@@ -128,19 +128,7 @@ export class XrplClient {
     });
   };
 
-  /**
-   * {@link https://xrpl.org/nftokenburn.html}
-   */
-  public burnNft = async (tokenId: string): Promise<TxResponse> => {
-    const wallet = await this.connectAndGetWallet();
-    const burnNftTxPayload: NFTokenBurn = {
-      TransactionType: 'NFTokenBurn',
-      Account: wallet.address,
-      TokenID: tokenId,
-    };
-
-    return this.#client.submitAndWait(burnNftTxPayload, { wallet });
-  };
+  public burnNft = burnNft.bind(this, this.stateRefProvider);
 
   public createNftSellOffer = createNftSellOffer.bind(
     null,

--- a/src/XrplSandbox/XrplClient.ts
+++ b/src/XrplSandbox/XrplClient.ts
@@ -16,6 +16,7 @@ import {
   createNftSellOffer,
   listNftBuyOffers,
   listNftSellOffers,
+  viewOwnNfts,
 } from './NFTokens/nftClient';
 
 export class XrplClient {
@@ -119,14 +120,7 @@ export class XrplClient {
     return this.#client.submitAndWait(nfTokenMintTxPayload, { wallet });
   };
 
-  public viewOwnNfts = async () => {
-    const wallet = await this.connectAndGetWallet();
-
-    return this.#client.request({
-      command: 'account_nfts',
-      account: wallet.address,
-    });
-  };
+  public viewOwnNfts = viewOwnNfts.bind(null, this.stateRefProvider);
 
   public burnNft = burnNft.bind(this, this.stateRefProvider);
 

--- a/src/XrplSandbox/XrplClient.ts
+++ b/src/XrplSandbox/XrplClient.ts
@@ -16,6 +16,7 @@ import {
   acceptNftBuyOffer,
   acceptNftSellOffer,
   cancelNftOffers,
+  listNftBuyOffers,
 } from './NFTokens/nftClient';
 
 export class XrplClient {
@@ -236,16 +237,7 @@ export class XrplClient {
     return this.#client.submitAndWait(nfTokenCreateBuyOfferPayload, { wallet });
   };
 
-  public listNftBuyOffers = async (tokenId: string) => {
-    try {
-      return await this.#client.request({
-        command: 'nft_buy_offers',
-        tokenid: tokenId,
-      });
-    } catch (error: unknown) {
-      return [];
-    }
-  };
+  public listNftBuyOffers = listNftBuyOffers.bind(null, this.stateRefProvider);
 
   public cancelNftOffers = cancelNftOffers.bind(null, this.stateRefProvider);
 

--- a/src/XrplSandbox/XrplClient.ts
+++ b/src/XrplSandbox/XrplClient.ts
@@ -2,7 +2,6 @@ import {
   Client,
   ClientOptions,
   NFTokenBurn,
-  NFTokenCancelOffer,
   NFTokenCreateOffer,
   NFTokenCreateOfferFlags,
   NFTokenMint,
@@ -13,7 +12,11 @@ import {
 } from 'xrpl';
 import { Amount } from 'xrpl/dist/npm/models/common';
 import { MS_IN_S, RIPPLE_EPOCH_IN_MS } from './constants';
-import { acceptNftBuyOffer, acceptNftSellOffer } from './NFTokens/nftClient';
+import {
+  acceptNftBuyOffer,
+  acceptNftSellOffer,
+  cancelNftOffers,
+} from './NFTokens/nftClient';
 
 export class XrplClient {
   #client: Client;
@@ -244,20 +247,7 @@ export class XrplClient {
     }
   };
 
-  /**
-   * {@link https://xrpl.org/nftokencanceloffer.html}
-   * @param tokenOfferIndices array of NFT offer `index`es
-   */
-  public cancelNftOffers = async (tokenOfferIndices: string[]) => {
-    const wallet = await this.connectAndGetWallet();
-    const cancelNftOffersPayload: NFTokenCancelOffer = {
-      TransactionType: 'NFTokenCancelOffer',
-      Account: wallet.address,
-      TokenOffers: tokenOfferIndices,
-    };
-
-    return this.#client.submitAndWait(cancelNftOffersPayload, { wallet });
-  };
+  public cancelNftOffers = cancelNftOffers.bind(null, this.stateRefProvider);
 
   public acceptNftSellOffer = acceptNftSellOffer.bind(
     null,

--- a/src/XrplSandbox/XrplClient.ts
+++ b/src/XrplSandbox/XrplClient.ts
@@ -76,39 +76,33 @@ export class XrplClient {
     return this.#client.submitAndWait(signed.tx_blob);
   };
 
+  /**
+   * NFT related methods
+   */
   public mintTransferableNft = mintTransferableNft.bind(
     null,
     this.stateRefProvider
   );
-
   public viewOwnNfts = viewOwnNfts.bind(null, this.stateRefProvider);
-
   public burnNft = burnNft.bind(this, this.stateRefProvider);
-
   public createNftSellOffer = createNftSellOffer.bind(
     null,
     this.stateRefProvider
   );
-
   public createNftBuyOffer = createNftBuyOffer.bind(
     null,
     this.stateRefProvider
   );
-
   public listNftSellOffers = listNftSellOffers.bind(
     null,
     this.stateRefProvider
   );
-
   public listNftBuyOffers = listNftBuyOffers.bind(null, this.stateRefProvider);
-
   public cancelNftOffers = cancelNftOffers.bind(null, this.stateRefProvider);
-
   public acceptNftSellOffer = acceptNftSellOffer.bind(
     null,
     this.stateRefProvider
   );
-
   public acceptNftBuyOffer = acceptNftBuyOffer.bind(
     null,
     this.stateRefProvider

--- a/src/XrplSandbox/XrplClient.ts
+++ b/src/XrplSandbox/XrplClient.ts
@@ -16,6 +16,7 @@ import {
   acceptNftBuyOffer,
   acceptNftSellOffer,
   cancelNftOffers,
+  createNftBuyOffer,
   listNftBuyOffers,
 } from './NFTokens/nftClient';
 
@@ -199,43 +200,10 @@ export class XrplClient {
     }
   };
 
-  /**
-   * Note that this transaction type is used for both BUY and SELLs.
-   * The differentiators are the various properties of the payload.
-   *
-   * BUY requires:
-   * - Owner of the NFT to be defined
-   * - No Flag.tfSellToken to be set
-   *
-   * {@link https://xrpl.org/nftokencreateoffer.html}
-   */
-  public createNftBuyOffer = async ({
-    amount,
-    owner,
-    tokenId,
-    destination,
-  }: {
-    amount: Amount | number;
-    owner: string;
-    tokenId: string;
-    destination?: string;
-  }): Promise<TxResponse> => {
-    const wallet = await this.connectAndGetWallet();
-    const nfTokenCreateBuyOfferPayload: NFTokenCreateOffer = {
-      TransactionType: 'NFTokenCreateOffer',
-      Account: wallet.address,
-      Amount: typeof amount === 'number' ? xrpToDrops(amount) : amount,
-      Owner: owner,
-      TokenID: tokenId,
-    };
-
-    // [To-Clarify] Is this field needed for buy offers?
-    if (destination) {
-      nfTokenCreateBuyOfferPayload.Destination = destination;
-    }
-
-    return this.#client.submitAndWait(nfTokenCreateBuyOfferPayload, { wallet });
-  };
+  public createNftBuyOffer = createNftBuyOffer.bind(
+    null,
+    this.stateRefProvider
+  );
 
   public listNftBuyOffers = listNftBuyOffers.bind(null, this.stateRefProvider);
 

--- a/src/XrplSandbox/XrplClient.ts
+++ b/src/XrplSandbox/XrplClient.ts
@@ -1,7 +1,6 @@
 import {
   Client,
   ClientOptions,
-  NFTokenAcceptOffer,
   NFTokenBurn,
   NFTokenCancelOffer,
   NFTokenCreateOffer,
@@ -14,7 +13,7 @@ import {
 } from 'xrpl';
 import { Amount } from 'xrpl/dist/npm/models/common';
 import { MS_IN_S, RIPPLE_EPOCH_IN_MS } from './constants';
-import { acceptNftBuyOffer } from './NFTokens/nftClient';
+import { acceptNftBuyOffer, acceptNftSellOffer } from './NFTokens/nftClient';
 
 export class XrplClient {
   #client: Client;
@@ -260,27 +259,10 @@ export class XrplClient {
     return this.#client.submitAndWait(cancelNftOffersPayload, { wallet });
   };
 
-  /**
-   * For cases where a buyer can accept a sell offer from a NFT owner.
-   * {@link https://xrpl.org/nftokenacceptoffer.html}
-   */
-  public acceptNftSellOffer = async (
-    offerIndex: string,
-    brokerFee?: Amount
-  ): Promise<TxResponse> => {
-    const wallet = await this.connectAndGetWallet();
-    const acceptNftSellOfferPayload: NFTokenAcceptOffer = {
-      TransactionType: 'NFTokenAcceptOffer',
-      Account: wallet.address,
-      SellOffer: offerIndex,
-    };
-
-    if (brokerFee) {
-      acceptNftSellOfferPayload.BrokerFee = brokerFee;
-    }
-
-    return this.#client.submitAndWait(acceptNftSellOfferPayload, { wallet });
-  };
+  public acceptNftSellOffer = acceptNftSellOffer.bind(
+    null,
+    this.stateRefProvider
+  );
 
   public acceptNftBuyOffer = acceptNftBuyOffer.bind(
     null,

--- a/src/XrplSandbox/XrplClient.ts
+++ b/src/XrplSandbox/XrplClient.ts
@@ -2,21 +2,18 @@ import {
   Client,
   ClientOptions,
   NFTokenBurn,
-  NFTokenCreateOffer,
-  NFTokenCreateOfferFlags,
   NFTokenMint,
   NFTokenMintFlags,
   TxResponse,
   Wallet,
   xrpToDrops,
 } from 'xrpl';
-import { Amount } from 'xrpl/dist/npm/models/common';
-import { MS_IN_S, RIPPLE_EPOCH_IN_MS } from './constants';
 import {
   acceptNftBuyOffer,
   acceptNftSellOffer,
   cancelNftOffers,
   createNftBuyOffer,
+  createNftSellOffer,
   listNftBuyOffers,
   listNftSellOffers,
 } from './NFTokens/nftClient';
@@ -145,50 +142,10 @@ export class XrplClient {
     return this.#client.submitAndWait(burnNftTxPayload, { wallet });
   };
 
-  /**
-   * Note that this transaction type is used for both BUY and SELLs.
-   * The differentiators are the various properties of the payload.
-   *
-   * SELL requires:
-   * - Flag.tfSellToken to be set
-   *
-   * {@link https://xrpl.org/nftokencreateoffer.html}
-   */
-  public createNftSellOffer = async ({
-    amount,
-    tokenId,
-    destination,
-    expirationISOString,
-  }: {
-    amount: Amount | number;
-    tokenId: string;
-    destination?: string;
-    expirationISOString?: string;
-  }): Promise<TxResponse> => {
-    const wallet = await this.connectAndGetWallet();
-    const nfTokenCreateSellOfferPayload: NFTokenCreateOffer = {
-      TransactionType: 'NFTokenCreateOffer',
-      Account: wallet.address,
-      Amount: typeof amount === 'number' ? xrpToDrops(amount) : amount,
-      TokenID: tokenId,
-      Flags: NFTokenCreateOfferFlags.tfSellToken,
-    };
-
-    if (destination) {
-      nfTokenCreateSellOfferPayload.Destination = destination;
-    }
-    if (expirationISOString) {
-      const dateTimeInMs = new Date(expirationISOString).getTime();
-      const differenceInMs = dateTimeInMs - RIPPLE_EPOCH_IN_MS;
-      nfTokenCreateSellOfferPayload.Expiration = Math.floor(
-        differenceInMs / MS_IN_S
-      );
-    }
-
-    return this.#client.submitAndWait(nfTokenCreateSellOfferPayload, {
-      wallet,
-    });
-  };
+  public createNftSellOffer = createNftSellOffer.bind(
+    null,
+    this.stateRefProvider
+  );
 
   public createNftBuyOffer = createNftBuyOffer.bind(
     null,

--- a/src/XrplSandbox/XrplClient.ts
+++ b/src/XrplSandbox/XrplClient.ts
@@ -1,12 +1,4 @@
-import {
-  Client,
-  ClientOptions,
-  NFTokenMint,
-  NFTokenMintFlags,
-  TxResponse,
-  Wallet,
-  xrpToDrops,
-} from 'xrpl';
+import { Client, ClientOptions, TxResponse, Wallet, xrpToDrops } from 'xrpl';
 import {
   acceptNftBuyOffer,
   acceptNftSellOffer,
@@ -16,6 +8,7 @@ import {
   createNftSellOffer,
   listNftBuyOffers,
   listNftSellOffers,
+  mintTransferableNft,
   viewOwnNfts,
 } from './NFTokens/nftClient';
 
@@ -83,42 +76,10 @@ export class XrplClient {
     return this.#client.submitAndWait(signed.tx_blob);
   };
 
-  /**
-   * Specifically mint a transferable NFT
-   * {@link https://xrpl.org/nftokenmint.html}
-   */
-  public mintTransferableNft = async ({
-    transferFee,
-    URI,
-  }: {
-    transferFee?: number;
-    URI?: string;
-  } = {}): Promise<TxResponse> => {
-    const wallet = await this.connectAndGetWallet();
-    const nfTokenMintTxPayload: NFTokenMint = {
-      TransactionType: 'NFTokenMint',
-      Account: wallet.address,
-      Flags: NFTokenMintFlags.tfTransferable,
-      TokenTaxon: 0, // [To-Clarify] What is the practical use case of the TokenTaxon?
-      /**
-       * Issuer field also requires the AccountRoot to have the `MintAccount` field set to wallet.address.
-       * This can be set through the {@link https://xrpl.org/accountset.html} AccountSet Tx.
-       */
-      // Issuer:     // [To-Clarify] What is the practical use case of having an Issuer account?
-    };
-
-    if (URI) {
-      nfTokenMintTxPayload.URI = URI;
-    }
-    // Throw an error instead if desired. See NFTokenMint transaction in jsdoc to see TransferFee constraints.
-    const isValidTransferFee =
-      !!transferFee && transferFee >= 0 && transferFee <= 9999;
-    if (isValidTransferFee) {
-      nfTokenMintTxPayload.TransferFee = transferFee;
-    }
-
-    return this.#client.submitAndWait(nfTokenMintTxPayload, { wallet });
-  };
+  public mintTransferableNft = mintTransferableNft.bind(
+    null,
+    this.stateRefProvider
+  );
 
   public viewOwnNfts = viewOwnNfts.bind(null, this.stateRefProvider);
 

--- a/src/XrplSandbox/XrplClient.ts
+++ b/src/XrplSandbox/XrplClient.ts
@@ -18,6 +18,7 @@ import {
   cancelNftOffers,
   createNftBuyOffer,
   listNftBuyOffers,
+  listNftSellOffers,
 } from './NFTokens/nftClient';
 
 export class XrplClient {
@@ -189,18 +190,12 @@ export class XrplClient {
     });
   };
 
-  public listNftSellOffers = async (tokenId: string) => {
-    try {
-      return await this.#client.request({
-        command: 'nft_sell_offers',
-        tokenid: tokenId,
-      });
-    } catch (error: unknown) {
-      return [];
-    }
-  };
-
   public createNftBuyOffer = createNftBuyOffer.bind(
+    null,
+    this.stateRefProvider
+  );
+
+  public listNftSellOffers = listNftSellOffers.bind(
     null,
     this.stateRefProvider
   );

--- a/src/XrplSandbox/XrplClient.ts
+++ b/src/XrplSandbox/XrplClient.ts
@@ -28,6 +28,11 @@ export class XrplClient {
   public client = () => this.#client;
   public wallet = () => this.#wallet;
 
+  private stateRefProvider = async () => {
+    const wallet = await this.connectAndGetWallet();
+    return { client: this.#client, wallet };
+  };
+
   private connect = (): Promise<void> => {
     if (this.#client.isConnected()) {
       return Promise.resolve();

--- a/src/XrplSandbox/scripts/CONFIG.ts
+++ b/src/XrplSandbox/scripts/CONFIG.ts
@@ -1,8 +1,21 @@
+const MUST_BE_REPLACED_VALUE = 'see-@link-for-tesnet-faucet';
+
 /**
  * See @link to get credentials from the NFT-Devnet XRP faucet.
  * > Generate NFT-Devnet credentials > Copy "Secret" > Use as *_FAUCET_WALLET_SECRET
  *
  * {@link https://xrpl.org/xrp-testnet-faucet.html}
  */
-export const CLIENT_ONE_FAUCET_WALLET_SECRET = 'see-@link-above';
-export const CLIENT_TWO_FAUCET_WALLET_SECRET = 'see-@link-above';
+export const CLIENT_ONE_FAUCET_WALLET_SECRET = MUST_BE_REPLACED_VALUE;
+export const CLIENT_TWO_FAUCET_WALLET_SECRET = MUST_BE_REPLACED_VALUE;
+
+if (
+  CLIENT_ONE_FAUCET_WALLET_SECRET === (MUST_BE_REPLACED_VALUE as string) ||
+  CLIENT_TWO_FAUCET_WALLET_SECRET === (MUST_BE_REPLACED_VALUE as string)
+) {
+  throw new Error(
+    `Must instantiate clients with secrets generated from the XRP Faucet Wallet.\n
+    Be sure to use the correct test or devnet corresponding to the functionalities you want to use.\n
+    https://xrpl.org/xrp-testnet-faucet.html`
+  );
+}

--- a/src/XrplSandbox/types.ts
+++ b/src/XrplSandbox/types.ts
@@ -1,4 +1,4 @@
-import { NFTokenMintFlags } from 'xrpl';
+import { Client, NFTokenMintFlags, Wallet } from 'xrpl';
 
 // Doesn't seem to be a general NFT interface in xrpl.js yet
 export interface NFT {
@@ -8,3 +8,15 @@ export interface NFT {
   TokenTaxon: number;
   nft_serial: number;
 }
+
+/** Properties provided by the sandbox XrplClient */
+export interface StateRefs {
+  wallet: Wallet;
+  client: Client;
+}
+
+/**
+ * Async data provider for properties provided by the sandbox XrplClient.
+ * Allows for functions to be agnostic of where wallet and client data comes from.
+ */
+export type StateRefProvider = () => Promise<StateRefs>;


### PR DESCRIPTION
## Summary

Before moving on to incorporating other XRPL related functionality, I thought it was prudent to try to modularize the NFT logic so that the code is more readable. As I add onto the client, it would be a nightmare to scan through a mega `XrplClient` class if all logic was kept there.

## Changes
- Move all NFT related logic to `src/XrplSandbox/NFTokens/nftClient.ts`
- Inject the `client` and `wallet` through a provider so that the functions can be relatively agnostic of the true source of that data.
